### PR TITLE
Bugfix: Update AVR_CPU_HZ to 2 MHz

### DIFF
--- a/ports/avr/atomport-private.h
+++ b/ports/avr/atomport-private.h
@@ -31,7 +31,7 @@
 #define __ATOM_PORT_PRIVATE_H
 
 /* CPU Frequency */
-#define AVR_CPU_HZ          1000000
+#define AVR_CPU_HZ          2000000
 
 /* Function prototypes */
 void avrInitSystemTickTimer ( void );


### PR DESCRIPTION
"Fixed AVR_CPU_HZ bug in ports/avr/atomport-private.h, updating from 1 MHz to 2 MHz"